### PR TITLE
Implemented add/delete label feature

### DIFF
--- a/protobuf/Label.proto
+++ b/protobuf/Label.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package task_manager;
+
+message Label
+{
+    string name = 1;
+}

--- a/protobuf/Task.proto
+++ b/protobuf/Task.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "Label.proto";
 
 package task_manager;
 
@@ -23,4 +24,5 @@ message Task
     google.protobuf.Timestamp due_date = 2;
     Priority priority = 3;
     Progress progress = 4;
+    repeated Label labels = 5;
 }

--- a/src/interactor/io_facility/Strings.cc
+++ b/src/interactor/io_facility/Strings.cc
@@ -105,7 +105,15 @@ std::string Strings::ShowSolidTask(SolidTask solid_task) {
      << to_string(solid_task.task().progress()) << "] "
      << "(" << to_string(solid_task.task().priority()) << ") "
      << "{" << std::put_time(localized_time, kDatePattern) << "} "
-     << "'" << solid_task.task().title() << "'\n";
+     << "'" << solid_task.task().title() << "' ";
+  if (solid_task.task().labels_size() != 0) {
+    ss << "( ";
+    for (const auto& i : solid_task.task().labels()) {
+      ss << i.name() << " ";
+    }
+    ss << ")";
+  }
+  ss << '\n';
   return ss.str();
 }
 

--- a/src/interactor/io_facility/Strings.h
+++ b/src/interactor/io_facility/Strings.h
@@ -24,7 +24,9 @@ constexpr ccp kMultipleArgumentDoesNotSupported =
     "Multiple arguments does not supported for this command.\n";
 constexpr ccp kRequiredId = "Id is required for this command.\n";
 constexpr ccp kInvalidId = "Invalid id format.\n";
+constexpr ccp kRequiredLabel = "Label is required for this command.\n";
 constexpr ccp kRepeatedId = "Repeated Ids are not allowed.\n";
+constexpr ccp kNotPresentLabel = "Given label wasn`t found\n";
 constexpr ccp kNotPresentId = "Given Id wasn`t found\n";
 constexpr ccp kHelp =
     "Usage:\n"

--- a/src/interactor/state_machine/StateMachineController.cc
+++ b/src/interactor/state_machine/StateMachineController.cc
@@ -17,6 +17,9 @@ StepEvent MCStatusToStepEvent(ModelController::Status status) {
 
     case ModelController::Status::kNotPresentId:
       return StepEvent::kNotPresentId;
+
+    case ModelController::Status::kNotPresentLabel:
+      return StepEvent::kNotPresentLabel;
   }
 }
 

--- a/src/interactor/state_machine/StepEvent.h
+++ b/src/interactor/state_machine/StepEvent.h
@@ -7,6 +7,7 @@ enum class StepEvent {
   kNotPresentId,
   kLoadFailure,
   kSaveFailure,
+  kNotPresentLabel,
 
   kShowAll,
   kShowById,

--- a/src/interactor/state_machine/commands/AddLabelCommand.cc
+++ b/src/interactor/state_machine/commands/AddLabelCommand.cc
@@ -1,0 +1,14 @@
+#include "Commands.h"
+
+namespace task_manager {
+AddLabelCommand::AddLabelCommand(TaskId task_id, Label label)
+    : task_id_(std::move(task_id)), label_(std::move(label)) {}
+
+CommandResult AddLabelCommand::execute(ModelController &model_controller) {
+  CommandResult ret;
+  auto result =
+      model_controller.AddLabel(std::move(task_id_), std::move(label_));
+  ret.status = result.GetStatus();
+  return ret;
+}
+}  // namespace task_manager

--- a/src/interactor/state_machine/commands/Commands.h
+++ b/src/interactor/state_machine/commands/Commands.h
@@ -99,6 +99,26 @@ class SaveTasksToFileCommand : public Command {
   FilePersistence persistence_;
 };
 
+class AddLabelCommand : public Command {
+ public:
+  AddLabelCommand(TaskId, Label);
+  CommandResult execute(ModelController&) override;
+
+ private:
+  TaskId task_id_;
+  Label label_;
+};
+
+class DeleteLabelCommand : public Command {
+ public:
+  DeleteLabelCommand(TaskId, Label);
+  CommandResult execute(ModelController&) override;
+
+ private:
+  TaskId task_id_;
+  Label label_;
+};
+
 class VoidCommand : public Command {
  public:
   CommandResult execute(ModelController&) override;

--- a/src/interactor/state_machine/commands/DeleteLabelCommand.cc
+++ b/src/interactor/state_machine/commands/DeleteLabelCommand.cc
@@ -1,0 +1,14 @@
+#include "Commands.h"
+
+namespace task_manager {
+DeleteLabelCommand::DeleteLabelCommand(TaskId task_id, Label label)
+    : task_id_(std::move(task_id)), label_(std::move(label)) {}
+
+CommandResult DeleteLabelCommand::execute(ModelController &model_controller) {
+  CommandResult ret;
+  auto result =
+      model_controller.DeleteLabel(std::move(task_id_), std::move(label_));
+  ret.status = result.GetStatus();
+  return ret;
+}
+}  // namespace task_manager

--- a/src/interactor/state_machine/interactor_steps/AddLabelStep.cc
+++ b/src/interactor/state_machine/interactor_steps/AddLabelStep.cc
@@ -1,0 +1,69 @@
+#include "AddLabelStep.h"
+
+#include "interactor/io_facility/Strings.h"
+#include "interactor/state_machine/interactor_steps/FinalizeStep.h"
+#include "utils/TaskIdUtils.h"
+
+namespace task_manager {
+
+std::unique_ptr<Command> AddLabelStep::execute(StepParameter &param) {
+  param.ctx.event = StepEvent::kNothing;
+  if (arg_.empty()) {
+    return ReportError(Strings::kRequiredId);
+  }
+
+  auto token = validator_->ConsumeOneTokenFrom(arg_);
+  auto to_edit = validator_->ParseInt(token);
+  if (!to_edit) {
+    return ReportError(Strings::InvalidId(token));
+  }
+
+  task_id_.set_id(*to_edit);
+  if (arg_.empty()) {
+    return ReportError(Strings::kRequiredLabel);
+  }
+
+  token = validator_->ConsumeOneTokenFrom(arg_);
+  if (!arg_.empty()) {
+    return ReportError(Strings::kMultipleArgumentDoesNotSupported);
+  }
+  label_.set_name(token);
+
+  auto found =
+      std::find_if(param.cache.begin(), param.cache.end(),
+                   [this](const auto &i) { return i.task_id() == task_id_; });
+  if (found != param.cache.end()) {
+    io_facility_->Print(Strings::YouAreGoingTo("add label to"));
+    io_facility_->Print(Strings::ShowSolidTask(*found));
+  }
+
+  io_facility_->Print(Strings::ProceedTo("add label"));
+  std::string input = io_facility_->GetLine();
+  auto confirm = validator_->ParseConfirmation(input);
+
+  if (!confirm) {
+    io_facility_->Print(Strings::kOkayITreatItAsNo);
+    return std::make_unique<VoidCommand>();
+  }
+
+  if (*confirm == ConfirmationResult::kNo) {
+    return std::make_unique<VoidCommand>();
+  }
+
+  if (found != param.cache.end()) {
+    auto label_ptr = found->mutable_task()->add_labels();
+    label_ptr->set_name(label_.name());
+  }
+  return std::make_unique<AddLabelCommand>(task_id_, label_);
+}
+
+void AddLabelStep::ChangeStep(std::shared_ptr<Step> &active_step) {
+  active_step = std::make_shared<FinalizeStep>(validator_, io_facility_,
+                                               small_step_factory_);
+}
+
+std::unique_ptr<Command> AddLabelStep::ReportError(std::string str) {
+  io_facility_->Print(str);
+  return std::make_unique<VoidCommand>();
+}
+}  // namespace task_manager

--- a/src/interactor/state_machine/interactor_steps/AddLabelStep.h
+++ b/src/interactor/state_machine/interactor_steps/AddLabelStep.h
@@ -13,9 +13,6 @@ class AddLabelStep : public Step, public ArgumentMixin {
 
  private:
   std::unique_ptr<Command> ReportError(std::string);
-
-  TaskId task_id_;
-  Label label_;
 };
 }  // namespace task_manager
 

--- a/src/interactor/state_machine/interactor_steps/AddLabelStep.h
+++ b/src/interactor/state_machine/interactor_steps/AddLabelStep.h
@@ -1,0 +1,22 @@
+#ifndef TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_ADDLABELSTEP_H_
+#define TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_ADDLABELSTEP_H_
+
+#include "interactor/state_machine/interactor_steps/Step.h"
+
+namespace task_manager {
+class AddLabelStep : public Step, public ArgumentMixin {
+ public:
+  using ArgumentMixin::ArgumentMixin;
+
+  std::unique_ptr<Command> execute(StepParameter&) override;
+  void ChangeStep(std::shared_ptr<Step>&) override;
+
+ private:
+  std::unique_ptr<Command> ReportError(std::string);
+
+  TaskId task_id_;
+  Label label_;
+};
+}  // namespace task_manager
+
+#endif  // TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_ADDLABELSTEP_H_

--- a/src/interactor/state_machine/interactor_steps/CommandEnum.h
+++ b/src/interactor/state_machine/interactor_steps/CommandEnum.h
@@ -13,6 +13,8 @@ enum class CommandEnum {
   kUnknown,
   kSave,
   kLoad,
+  kAddLabel,
+  kDeleteLabel,
 };
 }
 

--- a/src/interactor/state_machine/interactor_steps/DeleteLabelStep.cc
+++ b/src/interactor/state_machine/interactor_steps/DeleteLabelStep.cc
@@ -1,0 +1,75 @@
+#include "DeleteLabelStep.h"
+
+#include "interactor/io_facility/Strings.h"
+#include "interactor/state_machine/interactor_steps/FinalizeStep.h"
+#include "utils/TaskIdUtils.h"
+
+namespace task_manager {
+
+std::unique_ptr<Command> DeleteLabelStep::execute(StepParameter &param) {
+  param.ctx.event = StepEvent::kNothing;
+  if (arg_.empty()) {
+    return ReportError(Strings::kRequiredId);
+  }
+
+  auto token = validator_->ConsumeOneTokenFrom(arg_);
+  auto to_edit = validator_->ParseInt(token);
+  if (!to_edit) {
+    return ReportError(Strings::InvalidId(token));
+  }
+
+  task_id_.set_id(*to_edit);
+  if (arg_.empty()) {
+    return ReportError(Strings::kRequiredLabel);
+  }
+
+  token = validator_->ConsumeOneTokenFrom(arg_);
+  if (!arg_.empty()) {
+    return ReportError(Strings::kMultipleArgumentDoesNotSupported);
+  }
+  label_.set_name(token);
+
+  auto found =
+      std::find_if(param.cache.begin(), param.cache.end(),
+                   [this](const auto &i) { return i.task_id() == task_id_; });
+
+  if (found != param.cache.cend()) {
+    io_facility_->Print(Strings::YouAreGoingTo("delete label from"));
+    io_facility_->Print(Strings::ShowSolidTask(*found));
+  }
+
+  io_facility_->Print(Strings::ProceedTo("delete label"));
+  std::string input = io_facility_->GetLine();
+  auto confirm = validator_->ParseConfirmation(input);
+
+  if (!confirm) {
+    io_facility_->Print(Strings::kOkayITreatItAsNo);
+    return std::make_unique<VoidCommand>();
+  }
+
+  if (*confirm == ConfirmationResult::kNo) {
+    return std::make_unique<VoidCommand>();
+  }
+
+  if (found != param.cache.end()) {
+    auto found_label = std::find_if(
+        found->task().labels().begin(), found->task().labels().end(),
+        [this](auto &label) { return label.name() == label_.name(); });
+    if (found_label != found->task().labels().end()) {
+      found->mutable_task()->mutable_labels()->erase(found_label);
+    }
+  }
+
+  return std::make_unique<DeleteLabelCommand>(task_id_, label_);
+}
+
+void DeleteLabelStep::ChangeStep(std::shared_ptr<Step> &active_step) {
+  active_step = std::make_shared<FinalizeStep>(validator_, io_facility_,
+                                               small_step_factory_);
+}
+
+std::unique_ptr<Command> DeleteLabelStep::ReportError(std::string str) {
+  io_facility_->Print(str);
+  return std::make_unique<VoidCommand>();
+}
+}  // namespace task_manager

--- a/src/interactor/state_machine/interactor_steps/DeleteLabelStep.h
+++ b/src/interactor/state_machine/interactor_steps/DeleteLabelStep.h
@@ -1,0 +1,22 @@
+#ifndef TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_DELETELABELSTEP_H_
+#define TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_DELETELABELSTEP_H_
+
+#include "interactor/state_machine/interactor_steps/Step.h"
+
+namespace task_manager {
+class DeleteLabelStep : public Step, public ArgumentMixin {
+ public:
+  using ArgumentMixin::ArgumentMixin;
+
+  std::unique_ptr<Command> execute(StepParameter&) override;
+  void ChangeStep(std::shared_ptr<Step>&) override;
+
+ private:
+  std::unique_ptr<Command> ReportError(std::string);
+
+  TaskId task_id_;
+  Label label_;
+};
+}  // namespace task_manager
+
+#endif  // TASKMANAGER_SRC_INTERACTOR_STATE_MACHINE_INTERACTOR_STEPS_DELETELABELSTEP_H_

--- a/src/interactor/state_machine/interactor_steps/DeleteLabelStep.h
+++ b/src/interactor/state_machine/interactor_steps/DeleteLabelStep.h
@@ -13,9 +13,6 @@ class DeleteLabelStep : public Step, public ArgumentMixin {
 
  private:
   std::unique_ptr<Command> ReportError(std::string);
-
-  TaskId task_id_;
-  Label label_;
 };
 }  // namespace task_manager
 

--- a/src/interactor/state_machine/interactor_steps/FinalizeStep.cc
+++ b/src/interactor/state_machine/interactor_steps/FinalizeStep.cc
@@ -9,6 +9,10 @@ std::unique_ptr<Command> FinalizeStep::execute(StepParameter &param) {
     case StepEvent::kShowId:
       return ShowId(param);
 
+    case StepEvent::kNotPresentLabel:
+      io_facility_->Print(Strings::kNotPresentLabel);
+      return std::make_unique<VoidCommand>();
+
     case StepEvent::kNotPresentId:
       io_facility_->Print(Strings::kNotPresentId);
       return std::make_unique<VoidCommand>();

--- a/src/interactor/state_machine/interactor_steps/PromptStep.cc
+++ b/src/interactor/state_machine/interactor_steps/PromptStep.cc
@@ -2,8 +2,10 @@
 
 #include "interactor/io_facility/Strings.h"
 #include "interactor/state_machine/interactor_steps/AddStep.h"
+#include "interactor/state_machine/interactor_steps/AddLabelStep.h"
 #include "interactor/state_machine/interactor_steps/CompleteStep.h"
 #include "interactor/state_machine/interactor_steps/DeleteStep.h"
+#include "interactor/state_machine/interactor_steps/DeleteLabelStep.h"
 #include "interactor/state_machine/interactor_steps/EditStep.h"
 #include "interactor/state_machine/interactor_steps/HelpStep.h"
 #include "interactor/state_machine/interactor_steps/LoadStep.h"
@@ -42,6 +44,16 @@ void PromptStep::ChangeStep(std::shared_ptr<Step>& active_step) {
 
     case CommandEnum::kHelp:
       active_step = std::make_shared<HelpStep>(
+          validator_, io_facility_, small_step_factory_, std::move(arg));
+      return;
+
+    case CommandEnum::kAddLabel:
+      active_step = std::make_shared<AddLabelStep>(
+          validator_, io_facility_, small_step_factory_, std::move(arg));
+      return;
+
+    case CommandEnum::kDeleteLabel:
+      active_step = std::make_shared<DeleteLabelStep>(
           validator_, io_facility_, small_step_factory_, std::move(arg));
       return;
 

--- a/src/interactor/state_machine/interactor_steps/PromptStep.cc
+++ b/src/interactor/state_machine/interactor_steps/PromptStep.cc
@@ -1,11 +1,11 @@
 #include "interactor/state_machine/interactor_steps/PromptStep.h"
 
 #include "interactor/io_facility/Strings.h"
-#include "interactor/state_machine/interactor_steps/AddStep.h"
 #include "interactor/state_machine/interactor_steps/AddLabelStep.h"
+#include "interactor/state_machine/interactor_steps/AddStep.h"
 #include "interactor/state_machine/interactor_steps/CompleteStep.h"
-#include "interactor/state_machine/interactor_steps/DeleteStep.h"
 #include "interactor/state_machine/interactor_steps/DeleteLabelStep.h"
+#include "interactor/state_machine/interactor_steps/DeleteStep.h"
 #include "interactor/state_machine/interactor_steps/EditStep.h"
 #include "interactor/state_machine/interactor_steps/HelpStep.h"
 #include "interactor/state_machine/interactor_steps/LoadStep.h"

--- a/src/interactor/validator/DefaultValidator.cc
+++ b/src/interactor/validator/DefaultValidator.cc
@@ -44,6 +44,14 @@ CommandEnum DefaultValidator::MatchCommand(const std::string &str) {
   if (str == "load" || str == "lo") {
     return CommandEnum::kLoad;
   }
+
+  if (str == "add_label" || str == "al") {
+    return CommandEnum::kAddLabel;
+  }
+
+  if (str == "delete_label" || str == "dl") {
+    return CommandEnum::kDeleteLabel;
+  }
   return CommandEnum::kUnknown;
 }
 std::pair<CommandEnum, std::string> DefaultValidator::MakeRequest(

--- a/src/model/DefaultModelController.cc
+++ b/src/model/DefaultModelController.cc
@@ -14,6 +14,9 @@ MCStatus TMStatusToMCStatus(TaskManager::Status tmstatus) {
 
     case TaskManager::Status::kOk:
       return MCStatus::kOk;
+
+    case TaskManager::Status::kNotPresentLabel:
+      return MCStatus::kNotPresentLabel;
   }
 }
 
@@ -177,6 +180,26 @@ OperationResult<MCStatus> DefaultModelController::SaveTo(
   return OperationResult<Status>::Ok();
 }
 
+OperationResult<MCStatus> DefaultModelController::AddLabel(TaskId task_id,
+                                                           Label label) {
+  auto result = task_manager_->AddLabel(std::move(task_id), std::move(label));
+  if (result) {
+    return OperationResult<Status>::Ok();
+  }
+  return OperationResult<MCStatus>::Error(
+      TMStatusToMCStatus(result.GetStatus()));
+}
+OperationResult<MCStatus> DefaultModelController::DeleteLabel(TaskId task_id,
+                                                              Label label) {
+  auto result =
+      task_manager_->DeleteLabel(std::move(task_id), std::move(label));
+  if (result) {
+    return OperationResult<Status>::Ok();
+  }
+  return OperationResult<MCStatus>::Error(
+      TMStatusToMCStatus(result.GetStatus()));
+}
+
 std::optional<std::pair<TaskId, TaskId>> HasParentChildRelationship(
     const SolidTasks& tasks, const std::vector<TaskId>& ids) {
   std::unordered_map<TaskId, std::vector<TaskId>> visited;
@@ -199,4 +222,5 @@ std::optional<std::pair<TaskId, TaskId>> HasParentChildRelationship(
   }
   return {};
 }
+
 }  // namespace task_manager

--- a/src/model/DefaultModelController.h
+++ b/src/model/DefaultModelController.h
@@ -30,6 +30,9 @@ class DefaultModelController : public ModelController {
   OperationResult<Status> LoadFrom(Persistence&) override;
   OperationResult<Status> SaveTo(Persistence&) override;
 
+  OperationResult<Status> AddLabel(TaskId task_id, Label label) override;
+  OperationResult<Status> DeleteLabel(TaskId task_id, Label label) override;
+
  private:
   std::unique_ptr<TaskManager> task_manager_;
 };

--- a/src/model/ModelController.h
+++ b/src/model/ModelController.h
@@ -19,6 +19,7 @@ class ModelController {
     kNotPresentId,
     kLoadFailure,
     kSaveFailure,
+    kNotPresentLabel
   };
 
  public:
@@ -32,6 +33,9 @@ class ModelController {
       std::vector<TaskId>) = 0;
   virtual OperationResult<Status> LoadFrom(Persistence&) = 0;
   virtual OperationResult<Status> SaveTo(Persistence&) = 0;
+
+  virtual OperationResult<Status> AddLabel(TaskId task_id, Label label) = 0;
+  virtual OperationResult<Status> DeleteLabel(TaskId task_id, Label label) = 0;
 
   virtual ~ModelController() {}
 };

--- a/src/model/task_manager/TaskManager.cc
+++ b/src/model/task_manager/TaskManager.cc
@@ -86,6 +86,38 @@ OperationResult<TMStatus> TaskManager::Delete(TaskId id) {
   return OperationResult<Status>::Error(Status::kNotPresentId);
 }
 
+OperationResult<TMStatus> TaskManager::AddLabel(TaskId id, Label label) {
+  if (auto it = storage_.tasks.find(id); it != storage_.tasks.end()) {
+    auto& task = it->second;
+    if (std::find_if(task.labels().begin(), task.labels().end(),
+                     [&label](auto& stored_lable) {
+                       return label.name() == stored_lable.name();
+                     }) == task.labels().end()) {
+      auto new_label = task.add_labels();
+      *new_label = std::move(label);
+    }
+    return OperationResult<Status>::Ok();
+  }
+  return OperationResult<Status>::Error(Status::kNotPresentId);
+}
+
+OperationResult<TMStatus> TaskManager::DeleteLabel(TaskId id, Label label) {
+  if (auto it = storage_.tasks.find(id); it != storage_.tasks.end()) {
+    auto& task = it->second;
+    if (auto to_erase = std::find_if(task.labels().begin(), task.labels().end(),
+                                     [&label](auto& stored_lable) {
+                                       return label.name() ==
+                                              stored_lable.name();
+                                     });
+        to_erase != task.labels().end()) {
+      task.mutable_labels()->erase(to_erase);
+      return OperationResult<Status>::Ok();
+    }
+    return OperationResult<Status>::Error(Status::kNotPresentLabel);
+  }
+  return OperationResult<Status>::Error(Status::kNotPresentId);
+}
+
 OperationResult<TMStatus, TaskManager::Storage> TaskManager::Show() const {
   return OperationResult<Status, Storage>::Ok(storage_);
 }

--- a/src/model/task_manager/TaskManager.h
+++ b/src/model/task_manager/TaskManager.h
@@ -22,10 +22,7 @@ class TaskManager final {
     Roots roots;
   };
 
-  enum class Status {
-    kOk,
-    kNotPresentId,
-  };
+  enum class Status { kOk, kNotPresentId, kNotPresentLabel };
 
   explicit TaskManager(std::unique_ptr<ITaskIdProducer> id_producer);
 
@@ -37,6 +34,9 @@ class TaskManager final {
   OperationResult<Status> Edit(TaskId id, Task task);
   OperationResult<Status> Complete(TaskId id);
   OperationResult<Status> Delete(TaskId id);
+
+  OperationResult<Status> AddLabel(TaskId id, Label label);
+  OperationResult<Status> DeleteLabel(TaskId id, Label label);
 
   OperationResult<Status, Storage> Show() const;
 

--- a/tests/interactor/output/AddLabelOutput.cc
+++ b/tests/interactor/output/AddLabelOutput.cc
@@ -40,8 +40,6 @@ TEST_F(AddLabelOutputTest, AddLabelShowTasksAndDeleteLabelShowTasks) {
       Strings::ShowId(std::to_string(0)),
 
       Strings::GetPrompt(""),
-      Strings::YouAreGoingTo("add label to"),
-      Strings::ShowSolidTask(task),
       Strings::ProceedTo("add label"),
 
       Strings::GetPrompt(""),
@@ -113,8 +111,6 @@ TEST_F(AddLabelOutputTest, RandomConfirmation) {
       Strings::ShowId(std::to_string(0)),
 
       Strings::GetPrompt(""),
-      Strings::YouAreGoingTo("add label to"),
-      Strings::ShowSolidTask(task),
       Strings::ProceedTo("add label"),
       Strings::kOkayITreatItAsNo,
 

--- a/tests/interactor/output/AddLabelOutput.cc
+++ b/tests/interactor/output/AddLabelOutput.cc
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include "test_utils/ScenarioFramework.h"
+
+class AddLabelOutputTest : public ::testing::Test, protected ScenarioFramework {
+ protected:
+  void SetUp() override { return SetUpImpl(); }
+};
+
+TEST_F(AddLabelOutputTest, AddLabelShowTasksAndDeleteLabelShowTasks) {
+  std::stringstream ss;
+  auto time =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  ss << std::put_time(std::localtime(&time), kDatePattern);
+  std::string default_date = ss.str();
+
+  auto stringed_task = task_stringed_data_producer_.GetData();
+  auto task = TaskDataToSolidTask(stringed_task, 0);
+  auto task_with_label = task;
+  {
+    auto label = task_with_label.mutable_task()->add_labels();
+    label->set_name("foo");
+  }
+  auto [task_storage, output] = RunScenario(
+      {"a", stringed_task.title, stringed_task.date, stringed_task.priority,
+       stringed_task.state, "y", "add_label 0 foo", "y", "s",
+       "delete_label 0 foo", "y", "s", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::GetPrompt("title"),
+      Strings::LeaveEmptyFor(default_date),
+      Strings::GetPrompt("due date", kDatePattern),
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kLow)),
+      Strings::GetPrompt("priority"),
+      Strings::kStateShouldBe,
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kUncompleted)),
+      Strings::GetPrompt("state"),
+      Strings::ProceedTo("add"),
+      Strings::ShowId(std::to_string(0)),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("add label to"),
+      Strings::ShowSolidTask(task),
+      Strings::ProceedTo("add label"),
+
+      Strings::GetPrompt(""),
+      Strings::ShowSolidTasks({task_with_label}),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("delete label from"),
+      Strings::ShowSolidTask(task_with_label),
+      Strings::ProceedTo("delete label"),
+
+      Strings::GetPrompt(""),
+      Strings::ShowSolidTasks({task}),
+
+      Strings::GetPrompt(""),
+
+  };
+  ASSERT_EQ(output.size(), desired_output.size());
+
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}
+
+TEST_F(AddLabelOutputTest, AddLabelToNotPresentId) {
+  auto [task_storage, output] = RunScenario({"add_label 0 foo", "y", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::ProceedTo("add label"),
+      Strings::kNotPresentId,
+      Strings::GetPrompt(""),
+  };
+
+  ASSERT_EQ(output.size(), desired_output.size());
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}
+
+TEST_F(AddLabelOutputTest, RandomConfirmation) {
+  std::stringstream ss;
+  auto time =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  ss << std::put_time(std::localtime(&time), kDatePattern);
+  std::string default_date = ss.str();
+
+  auto stringed_task = task_stringed_data_producer_.GetData();
+  auto task = TaskDataToSolidTask(stringed_task, 0);
+  auto task_with_label = task;
+  {
+    auto label = task_with_label.mutable_task()->add_labels();
+    label->set_name("foo");
+  }
+  auto [task_storage, output] = RunScenario(
+      {"a", stringed_task.title, stringed_task.date, stringed_task.priority,
+       stringed_task.state, "y", "add_label 0 foo", "fla", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::GetPrompt("title"),
+      Strings::LeaveEmptyFor(default_date),
+      Strings::GetPrompt("due date", kDatePattern),
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kLow)),
+      Strings::GetPrompt("priority"),
+      Strings::kStateShouldBe,
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kUncompleted)),
+      Strings::GetPrompt("state"),
+      Strings::ProceedTo("add"),
+      Strings::ShowId(std::to_string(0)),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("add label to"),
+      Strings::ShowSolidTask(task),
+      Strings::ProceedTo("add label"),
+      Strings::kOkayITreatItAsNo,
+
+      Strings::GetPrompt(""),
+  };
+  ASSERT_EQ(output.size(), desired_output.size());
+
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}

--- a/tests/interactor/output/DeleteLabelOutput.cc
+++ b/tests/interactor/output/DeleteLabelOutput.cc
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include "test_utils/ScenarioFramework.h"
+
+class DeleteLabelOutputTest : public ::testing::Test,
+                              protected ScenarioFramework {
+ protected:
+  void SetUp() override { return SetUpImpl(); }
+};
+
+TEST_F(DeleteLabelOutputTest, DeleteLabelToNotPresentId) {
+  auto [task_storage, output] = RunScenario({"delete_label 0 foo", "y", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::ProceedTo("delete label"),
+      Strings::kNotPresentId,
+      Strings::GetPrompt(""),
+  };
+
+  ASSERT_EQ(output.size(), desired_output.size());
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}
+
+TEST_F(DeleteLabelOutputTest, DeleteLabelNotPresentLable) {
+  std::stringstream ss;
+  auto time =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  ss << std::put_time(std::localtime(&time), kDatePattern);
+  std::string default_date = ss.str();
+
+  auto stringed_task = task_stringed_data_producer_.GetData();
+  auto task = TaskDataToSolidTask(stringed_task, 0);
+  auto task_with_label = task;
+  {
+    auto label = task_with_label.mutable_task()->add_labels();
+    label->set_name("foo");
+  }
+  auto [task_storage, output] = RunScenario(
+      {"a", stringed_task.title, stringed_task.date, stringed_task.priority,
+       stringed_task.state, "y", "delete_label 0 foo", "y", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::GetPrompt("title"),
+      Strings::LeaveEmptyFor(default_date),
+      Strings::GetPrompt("due date", kDatePattern),
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kLow)),
+      Strings::GetPrompt("priority"),
+      Strings::kStateShouldBe,
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kUncompleted)),
+      Strings::GetPrompt("state"),
+      Strings::ProceedTo("add"),
+      Strings::ShowId(std::to_string(0)),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("delete label from"),
+      Strings::ShowSolidTask(TaskDataToSolidTask(stringed_task, 0)),
+      Strings::ProceedTo("delete label"),
+      Strings::kNotPresentLabel,
+
+      Strings::GetPrompt(""),
+  };
+  ASSERT_EQ(output.size(), desired_output.size());
+
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}
+
+TEST_F(DeleteLabelOutputTest, RandomConfirmation) {
+  std::stringstream ss;
+  auto time =
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  ss << std::put_time(std::localtime(&time), kDatePattern);
+  std::string default_date = ss.str();
+
+  auto stringed_task = task_stringed_data_producer_.GetData();
+  auto task = TaskDataToSolidTask(stringed_task, 0);
+  auto task_with_label = task;
+  {
+    auto label = task_with_label.mutable_task()->add_labels();
+    label->set_name("foo");
+  }
+  auto [task_storage, output] =
+      RunScenario({"a", stringed_task.title, stringed_task.date,
+                   stringed_task.priority, stringed_task.state, "y",
+                   "add_label 0 foo", "y", "delete_label 0 foo", "fla", "q"});
+
+  std::vector<std::string> desired_output{
+      Strings::GetPrompt(""),
+      Strings::GetPrompt("title"),
+      Strings::LeaveEmptyFor(default_date),
+      Strings::GetPrompt("due date", kDatePattern),
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kLow)),
+      Strings::GetPrompt("priority"),
+      Strings::kStateShouldBe,
+      Strings::LeaveEmptyFor(Strings::to_string(Task::kUncompleted)),
+      Strings::GetPrompt("state"),
+      Strings::ProceedTo("add"),
+      Strings::ShowId(std::to_string(0)),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("add label to"),
+      Strings::ShowSolidTask(task),
+      Strings::ProceedTo("add label"),
+
+      Strings::GetPrompt(""),
+      Strings::YouAreGoingTo("delete label from"),
+      Strings::ShowSolidTask(task_with_label),
+      Strings::ProceedTo("delete label"),
+      Strings::kOkayITreatItAsNo,
+
+      Strings::GetPrompt(""),
+  };
+  ASSERT_EQ(output.size(), desired_output.size());
+
+  for (size_t i{0}, sz{output.size()}; i != sz; ++i) {
+    EXPECT_EQ(output[i], desired_output[i]);
+  }
+}

--- a/tests/interactor/output/DeleteLabelOutput.cc
+++ b/tests/interactor/output/DeleteLabelOutput.cc
@@ -56,8 +56,6 @@ TEST_F(DeleteLabelOutputTest, DeleteLabelNotPresentLable) {
       Strings::ShowId(std::to_string(0)),
 
       Strings::GetPrompt(""),
-      Strings::YouAreGoingTo("delete label from"),
-      Strings::ShowSolidTask(TaskDataToSolidTask(stringed_task, 0)),
       Strings::ProceedTo("delete label"),
       Strings::kNotPresentLabel,
 
@@ -103,13 +101,9 @@ TEST_F(DeleteLabelOutputTest, RandomConfirmation) {
       Strings::ShowId(std::to_string(0)),
 
       Strings::GetPrompt(""),
-      Strings::YouAreGoingTo("add label to"),
-      Strings::ShowSolidTask(task),
       Strings::ProceedTo("add label"),
 
       Strings::GetPrompt(""),
-      Strings::YouAreGoingTo("delete label from"),
-      Strings::ShowSolidTask(task_with_label),
       Strings::ProceedTo("delete label"),
       Strings::kOkayITreatItAsNo,
 

--- a/tests/interactor/unit/state_machine/commands/AddLabelCommand.cc
+++ b/tests/interactor/unit/state_machine/commands/AddLabelCommand.cc
@@ -1,0 +1,19 @@
+#include "interactor/state_machine/commands/Commands.h"
+#include "interactor/unit/state_machine/commands/CommandTest.h"
+#include "test_utils/operators.h"
+
+class AddLabelCommandTest : public CommandTest {};
+
+TEST_F(AddLabelCommandTest, MustAddLabel) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  AddLabelCommand add_label_command{id, label};
+  auto command_result = add_label_command.execute(*model_controller_);
+  ASSERT_EQ(command_result.status, ModelController::Status::kOk);
+  auto storage = model_controller_->GetAllSolidTasks().AccessResult();
+  auto got_task = storage.at(0).task();
+  ASSERT_EQ(got_task.labels_size(), 1);
+  EXPECT_EQ(got_task.labels()[0].name(), label.name());
+}

--- a/tests/interactor/unit/state_machine/commands/DeleteLabelCommand.cc
+++ b/tests/interactor/unit/state_machine/commands/DeleteLabelCommand.cc
@@ -1,0 +1,19 @@
+#include "interactor/state_machine/commands/Commands.h"
+#include "interactor/unit/state_machine/commands/CommandTest.h"
+#include "test_utils/operators.h"
+
+class DeleteLabelCommandTest : public CommandTest {};
+
+TEST_F(DeleteLabelCommandTest, MustDeleteLabel) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  model_controller_->AddLabel(id, label);
+  DeleteLabelCommand delete_label_command{id, label};
+  auto command_result = delete_label_command.execute(*model_controller_);
+  ASSERT_EQ(command_result.status, ModelController::Status::kOk);
+  auto storage = model_controller_->GetAllSolidTasks().AccessResult();
+  auto got_task = storage.at(0).task();
+  ASSERT_EQ(got_task.labels_size(), 0);
+}

--- a/tests/interactor/unit/state_machine/interactor_steps/AddLabelStep.cc
+++ b/tests/interactor/unit/state_machine/interactor_steps/AddLabelStep.cc
@@ -1,0 +1,73 @@
+#include "interactor/state_machine/interactor_steps/AddLabelStep.h"
+
+#include "StepTest.h"
+#include "interactor/state_machine/interactor_steps/FinalizeStep.h"
+#include "test_utils/TaskFactory.h"
+#include "test_utils/utils.h"
+
+class AddLabelStepTest : public StepTest {
+ public:
+  void SetUp() override { StepTest::SetUp(); }
+
+ protected:
+  void SetArg(std::string arg) {
+    step_ = std::make_unique<AddLabelStep>(validator_, io_facility_,
+                                           small_step_factory_, std::move(arg));
+  }
+  StepParameter step_parameter_;
+  std::unique_ptr<AddLabelStep> step_;
+};
+
+TEST_F(AddLabelStepTest, ExecuteWithoutArgumentMustReturnVoidCommand) {
+  SetArg("");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ExecuteWithIdButWithoutLabelMustReturnVoidCommand) {
+  SetArg("12");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ExecuteWithInvalidIdAndLabelMustReturnVoidCommand) {
+  SetArg("a foo");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ExecuteWithThirdArgumentMustReturnVoidCommand) {
+  SetArg("12 foo 34");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ExecuteWithRandomConfirmationMustReturnVoidCommand) {
+  SetArg("12 foo");
+  SetInput({"dfa"});
+  auto command = step_->execute(step_parameter_);
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, SecondCallWithConfirmationNoMustReturnVoidCommand) {
+  SetArg("12 foo");
+  SetInput({"n"});
+  auto command = step_->execute(step_parameter_);
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ExecuteWithIdAndLabelMustReturnAddLabelCommand) {
+  SetArg("12 foo");
+  SetInput({"y"});
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<AddLabelCommand*>(command.get()), nullptr);
+}
+
+TEST_F(AddLabelStepTest, ChangeStepMustChangeToFinalizeStep) {
+  SetArg("12 foo");
+  std::shared_ptr<Step> to_change{std::make_shared<StepChangeStepTesting>()};
+  auto old_addr = to_change.get();
+  step_->ChangeStep(to_change);
+  EXPECT_NE(to_change.get(), old_addr);
+  EXPECT_NE(dynamic_cast<FinalizeStep*>(to_change.get()), nullptr);
+}

--- a/tests/interactor/unit/state_machine/interactor_steps/DeleteLabelStep.cc
+++ b/tests/interactor/unit/state_machine/interactor_steps/DeleteLabelStep.cc
@@ -1,0 +1,74 @@
+#include "interactor/state_machine/interactor_steps/DeleteLabelStep.h"
+
+#include "StepTest.h"
+#include "interactor/state_machine/interactor_steps/FinalizeStep.h"
+#include "test_utils/TaskFactory.h"
+#include "test_utils/utils.h"
+
+class DeleteLabelStepTest : public StepTest {
+ public:
+  void SetUp() override { StepTest::SetUp(); }
+
+ protected:
+  void SetArg(std::string arg) {
+    step_ = std::make_unique<DeleteLabelStep>(
+        validator_, io_facility_, small_step_factory_, std::move(arg));
+  }
+  std::unique_ptr<DeleteLabelStep> step_;
+  StepParameter step_parameter_;
+};
+
+TEST_F(DeleteLabelStepTest, ExecuteWithoutArgumentMustReturnVoidCommand) {
+  SetArg("");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, ExecuteWithIdButWithoutLabelMustReturnVoidCommand) {
+  SetArg("12");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, ExecuteWithInvalidIdAndLabelMustReturnVoidCommand) {
+  SetArg("a foo");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, ExecuteWithThirdArgumentMustReturnVoidCommand) {
+  SetArg("12 foo 34");
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest,
+       ExecuteWithRandomConfirmationMustReturnVoidCommand) {
+  SetArg("12 foo");
+  SetInput({"dfa"});
+  auto command = step_->execute(step_parameter_);
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, SecondCallWithConfirmationNoMustReturnVoidCommand) {
+  SetArg("12 foo");
+  SetInput({"n"});
+  auto command = step_->execute(step_parameter_);
+  EXPECT_NE(dynamic_cast<VoidCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, ExecuteWithIdAndLabelMustReturnDeleteLabelCommand) {
+  SetArg("12 foo");
+  SetInput({"y"});
+  auto command{step_->execute(step_parameter_)};
+  EXPECT_NE(dynamic_cast<DeleteLabelCommand*>(command.get()), nullptr);
+}
+
+TEST_F(DeleteLabelStepTest, ChangeStepMustChangeToFinalizeStep) {
+  SetArg("12 foo");
+  std::shared_ptr<Step> to_change{std::make_shared<StepChangeStepTesting>()};
+  auto old_addr = to_change.get();
+  step_->ChangeStep(to_change);
+  EXPECT_NE(to_change.get(), old_addr);
+  EXPECT_NE(dynamic_cast<FinalizeStep*>(to_change.get()), nullptr);
+}

--- a/tests/interactor/unit/validator/DefaultValidator.cc
+++ b/tests/interactor/unit/validator/DefaultValidator.cc
@@ -32,6 +32,13 @@ TEST_F(DefaultValidatorTest, MustAcceptShortAndLongVariantsOfCommands) {
 
   EXPECT_EQ(validator_.MakeRequest("quit").first, CommandEnum::kQuit);
   EXPECT_EQ(validator_.MakeRequest("q").first, CommandEnum::kQuit);
+
+  EXPECT_EQ(validator_.MakeRequest("add_label").first, CommandEnum::kAddLabel);
+  EXPECT_EQ(validator_.MakeRequest("al").first, CommandEnum::kAddLabel);
+
+  EXPECT_EQ(validator_.MakeRequest("delete_label").first,
+            CommandEnum::kDeleteLabel);
+  EXPECT_EQ(validator_.MakeRequest("dl").first, CommandEnum::kDeleteLabel);
 }
 
 TEST_F(DefaultValidatorTest, CommandsMustBeCaseInsensitive) {
@@ -42,6 +49,9 @@ TEST_F(DefaultValidatorTest, CommandsMustBeCaseInsensitive) {
   EXPECT_EQ(validator_.MakeRequest("SHow").first, CommandEnum::kShow);
   EXPECT_EQ(validator_.MakeRequest("HElp").first, CommandEnum::kHelp);
   EXPECT_EQ(validator_.MakeRequest("QUiT").first, CommandEnum::kQuit);
+  EXPECT_EQ(validator_.MakeRequest("aDD_LaBel").first, CommandEnum::kAddLabel);
+  EXPECT_EQ(validator_.MakeRequest("DeleTE_LaBel").first,
+            CommandEnum::kDeleteLabel);
 }
 
 TEST_F(DefaultValidatorTest, EmptyTitleIsNullopt) {

--- a/tests/model/model_controller/DefaultModelController.cc
+++ b/tests/model/model_controller/DefaultModelController.cc
@@ -260,3 +260,78 @@ TEST_F(DefaultModelControllerTest, GetSpecificSolidTasks) {
     EXPECT_EQ(result.AccessResult()[i], expected[i]);
   }
 }
+
+TEST_F(DefaultModelControllerTest, MustAddLabel) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kOk);
+  auto storage = model_controller_->GetAllSolidTasks().AccessResult();
+  auto got_task = storage.at(0).task();
+  ASSERT_EQ(got_task.labels_size(), 1);
+  EXPECT_EQ(got_task.labels()[0].name(), label.name());
+}
+
+TEST_F(DefaultModelControllerTest, MustDeleteLabel) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kOk);
+  result = model_controller_->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kOk);
+  auto storage = model_controller_->GetAllSolidTasks().AccessResult();
+  auto got_task = storage.at(0).task();
+  ASSERT_EQ(got_task.labels_size(), 0);
+}
+
+TEST_F(DefaultModelControllerTest,
+       AddLabelWithNotPresentIdMustResultInkNotPresentId) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  model_controller_->Delete(id);
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kNotPresentId);
+}
+
+TEST_F(DefaultModelControllerTest,
+       AddLabelWithRepeatedLabelMustNotAddItAndReturnkOk) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kOk);
+  result = model_controller_->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kOk);
+  auto storage = model_controller_->GetAllSolidTasks().AccessResult();
+  auto got_task = storage.at(0).task();
+  ASSERT_EQ(got_task.labels_size(), 1);
+  EXPECT_EQ(got_task.labels()[0].name(), label.name());
+}
+
+TEST_F(DefaultModelControllerTest,
+       DeleteLabelWithNotPresentIdMustResultInkNotPresentId) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  model_controller_->Delete(id);
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kNotPresentId);
+}
+
+TEST_F(DefaultModelControllerTest,
+       DeleteLabelWithNotPresentLabelMustResultInkNotPresentLabel) {
+  auto task = task_factory_.GetNextTask();
+  auto id = model_controller_->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = model_controller_->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), ModelController::Status::kNotPresentLabel);
+}

--- a/tests/model/task_manager/TaskManager.cc
+++ b/tests/model/task_manager/TaskManager.cc
@@ -16,22 +16,16 @@ std::unique_ptr<ITaskIdProducer> get_default_task_id_producer() {
   return std::make_unique<MockTaskIdProducer>();
 }
 
-class TaskManagerTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    auto id_producer = get_default_task_id_producer();
-    tm = std::make_unique<TaskManager>(std::move(id_producer));
-  }
-
-  TaskFactory tf;
-  std::unique_ptr<TaskManager> tm;
-};
+class TaskManagerTest : public ::testing::Test {};
 
 TEST_F(TaskManagerTest, TaskAddedProperly) {
+  auto id_producer = get_default_task_id_producer();
+  TaskFactory tf;
+  TaskManager tm{std::move(id_producer)};
   auto task = tf.GetNextTask();
-  auto result = tm->Add(task);
+  auto result = tm.Add(task);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
   ASSERT_EQ(storage.tasks.size(), 1);
   ASSERT_EQ(storage.parents.size(), 1);
   ASSERT_EQ(storage.roots.size(), 1);
@@ -39,50 +33,58 @@ TEST_F(TaskManagerTest, TaskAddedProperly) {
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnDeleteWithUnexistingId) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto _ = tm->Add(task);
-  auto storage = tm->Show().AccessResult();
+  auto _ = tm.Add(task);
+  auto storage = tm.Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm->Delete(tmp_id);
-  EXPECT_EQ(tm->Delete(tmp_id).GetStatus(), TaskManager::Status::kNotPresentId);
+  tm.Delete(tmp_id);
+  EXPECT_EQ(tm.Delete(tmp_id).GetStatus(), TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnCompleteWithUnexistingId) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  tm->Add(task);
-  auto storage = tm->Show().AccessResult();
+  tm.Add(task);
+  auto storage = tm.Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm->Delete(tmp_id);
-  EXPECT_EQ(tm->Complete(tmp_id).GetStatus(),
+  tm.Delete(tmp_id);
+  EXPECT_EQ(tm.Complete(tmp_id).GetStatus(),
             TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnEditWithUnexistingId) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  tm->Add(task);
-  auto storage = tm->Show().AccessResult();
+  tm.Add(task);
+  auto storage = tm.Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm->Delete(tmp_id);
-  EXPECT_EQ(tm->Edit(tmp_id, task).GetStatus(),
+  tm.Delete(tmp_id);
+  EXPECT_EQ(tm.Edit(tmp_id, task).GetStatus(),
             TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, ProperDeletion) {
   constexpr int kElems = 512;
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
-    tm->Add(task);
+    tm.Add(task);
   }
-  auto storage = tm->Show();
+  auto storage = tm.Show();
   ASSERT_EQ(storage.AccessResult().parents.size(), kElems);
   ASSERT_EQ(storage.AccessResult().tasks.size(), kElems);
   ASSERT_EQ(storage.AccessResult().roots.size(), kElems);
 
   for (const auto& i : storage.AccessResult().roots) {
-    tm->Delete(i);
+    tm.Delete(i);
   }
-  storage = tm->Show();
+  storage = tm.Show();
 
   ASSERT_EQ(storage.AccessResult().parents.size(), 0);
   ASSERT_EQ(storage.AccessResult().tasks.size(), 0);
@@ -91,18 +93,20 @@ TEST_F(TaskManagerTest, ProperDeletion) {
 
 TEST_F(TaskManagerTest, ProperCompletion) {
   constexpr int kElems = 512;
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
-    tm->Add(task);
+    tm.Add(task);
   }
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
 
   for (const auto& i : storage.roots) {
-    tm->Complete(i);
+    tm.Complete(i);
   }
 
-  storage = tm->Show().AccessResult();
+  storage = tm.Show().AccessResult();
   for (const auto& i : storage.roots) {
     ASSERT_EQ(storage.tasks[i].progress(), Task::kCompleted);
   }
@@ -110,27 +114,29 @@ TEST_F(TaskManagerTest, ProperCompletion) {
 
 TEST_F(TaskManagerTest, ProperEdition) {
   constexpr int kElems = 256;
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   std::vector<Task> vec_tasks;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
     auto new_task = tf.GetNextTask();
-    tm->Add(task);
-    auto storage = tm->Show().AccessResult();
+    tm.Add(task);
+    auto storage = tm.Show().AccessResult();
     auto res = std::find_if(storage.tasks.cbegin(), storage.tasks.cend(),
                             [task](const auto& t) { return t.second == task; });
-    tm->Edit(res->first, new_task);
+    tm.Edit(res->first, new_task);
     vec_tasks.push_back(new_task);
   }
 
   for (const auto& i : vec_tasks) {
-    auto storage = tm->Show().AccessResult();
+    auto storage = tm.Show().AccessResult();
     auto iter = std::find_if(storage.tasks.cbegin(), storage.tasks.cend(),
                              [i](const auto& t) { return t.second == i; });
-    tm->Delete(iter->first);
+    tm.Delete(iter->first);
   }
 
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
 
   ASSERT_EQ(storage.parents.size(), 0);
   ASSERT_EQ(storage.tasks.size(), 0);
@@ -138,75 +144,86 @@ TEST_F(TaskManagerTest, ProperEdition) {
 }
 
 TEST_F(TaskManagerTest, MustAddLabel) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
+  auto id = tm.Add(task).AccessResult();
   Label label;
   label.set_name("label1");
-  auto result = tm->AddLabel(id, label);
+  auto result = tm.AddLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
   auto got_task = storage.tasks.at(id);
   ASSERT_EQ(got_task.labels_size(), 1);
   EXPECT_EQ(got_task.labels()[0].name(), label.name());
 }
 
 TEST_F(TaskManagerTest, MustDeleteLabel) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
+  auto id = tm.Add(task).AccessResult();
   Label label;
   label.set_name("label1");
-  auto result = tm->AddLabel(id, label);
+  auto result = tm.AddLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  result = tm->DeleteLabel(id, label);
+  result = tm.DeleteLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
   auto got_task = storage.tasks.at(id);
   ASSERT_EQ(got_task.labels_size(), 0);
 }
 
 TEST_F(TaskManagerTest, AddLabelWithNotPresentIdMustResultInkNotPresentId) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
-  tm->Delete(id);
+  auto id = tm.Add(task).AccessResult();
+  tm.Delete(id);
   Label label;
   label.set_name("label1");
-  auto result = tm->AddLabel(id, label);
+  auto result = tm.AddLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, AddLabelWithRepeatedLabelMustNotAddItAndReturnkOk) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
+  auto id = tm.Add(task).AccessResult();
   Label label;
   label.set_name("label1");
-  auto result = tm->AddLabel(id, label);
+  auto result = tm.AddLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  result = tm->AddLabel(id, label);
+  result = tm.AddLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  auto storage = tm->Show().AccessResult();
+  auto storage = tm.Show().AccessResult();
   auto got_task = storage.tasks.at(id);
   ASSERT_EQ(got_task.labels_size(), 1);
   EXPECT_EQ(got_task.labels()[0].name(), label.name());
 }
 
 TEST_F(TaskManagerTest, DeleteLabelWithNotPresentIdMustResultInkNotPresentId) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
-  tm->Delete(id);
+  auto id = tm.Add(task).AccessResult();
+  tm.Delete(id);
   Label label;
   label.set_name("label1");
-  auto result = tm->DeleteLabel(id, label);
+  auto result = tm.DeleteLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest,
        DeleteLabelWithNotPresentLabelMustResultInkNotPresentLabel) {
+  TaskManager tm{get_default_task_id_producer()};
+  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto id = tm->Add(task).AccessResult();
+  auto id = tm.Add(task).AccessResult();
   Label label;
   label.set_name("label1");
-  auto result = tm->DeleteLabel(id, label);
+  auto result = tm.DeleteLabel(id, label);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentLabel);
 }
-
 // TODO: Add tests for nested things

--- a/tests/model/task_manager/TaskManager.cc
+++ b/tests/model/task_manager/TaskManager.cc
@@ -16,16 +16,22 @@ std::unique_ptr<ITaskIdProducer> get_default_task_id_producer() {
   return std::make_unique<MockTaskIdProducer>();
 }
 
-class TaskManagerTest : public ::testing::Test {};
+class TaskManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto id_producer = get_default_task_id_producer();
+    tm = std::make_unique<TaskManager>(std::move(id_producer));
+  }
+
+  TaskFactory tf;
+  std::unique_ptr<TaskManager> tm;
+};
 
 TEST_F(TaskManagerTest, TaskAddedProperly) {
-  auto id_producer = get_default_task_id_producer();
-  TaskFactory tf;
-  TaskManager tm{std::move(id_producer)};
   auto task = tf.GetNextTask();
-  auto result = tm.Add(task);
+  auto result = tm->Add(task);
   ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
-  auto storage = tm.Show().AccessResult();
+  auto storage = tm->Show().AccessResult();
   ASSERT_EQ(storage.tasks.size(), 1);
   ASSERT_EQ(storage.parents.size(), 1);
   ASSERT_EQ(storage.roots.size(), 1);
@@ -33,58 +39,50 @@ TEST_F(TaskManagerTest, TaskAddedProperly) {
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnDeleteWithUnexistingId) {
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
   auto task = tf.GetNextTask();
-  auto _ = tm.Add(task);
-  auto storage = tm.Show().AccessResult();
+  auto _ = tm->Add(task);
+  auto storage = tm->Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm.Delete(tmp_id);
-  EXPECT_EQ(tm.Delete(tmp_id).GetStatus(), TaskManager::Status::kNotPresentId);
+  tm->Delete(tmp_id);
+  EXPECT_EQ(tm->Delete(tmp_id).GetStatus(), TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnCompleteWithUnexistingId) {
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
   auto task = tf.GetNextTask();
-  tm.Add(task);
-  auto storage = tm.Show().AccessResult();
+  tm->Add(task);
+  auto storage = tm->Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm.Delete(tmp_id);
-  EXPECT_EQ(tm.Complete(tmp_id).GetStatus(),
+  tm->Delete(tmp_id);
+  EXPECT_EQ(tm->Complete(tmp_id).GetStatus(),
             TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, InvalidIdResultOnEditWithUnexistingId) {
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
   auto task = tf.GetNextTask();
-  tm.Add(task);
-  auto storage = tm.Show().AccessResult();
+  tm->Add(task);
+  auto storage = tm->Show().AccessResult();
   auto tmp_id = storage.roots[0];
-  tm.Delete(tmp_id);
-  EXPECT_EQ(tm.Edit(tmp_id, task).GetStatus(),
+  tm->Delete(tmp_id);
+  EXPECT_EQ(tm->Edit(tmp_id, task).GetStatus(),
             TaskManager::Status::kNotPresentId);
 }
 
 TEST_F(TaskManagerTest, ProperDeletion) {
   constexpr int kElems = 512;
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
-    tm.Add(task);
+    tm->Add(task);
   }
-  auto storage = tm.Show();
+  auto storage = tm->Show();
   ASSERT_EQ(storage.AccessResult().parents.size(), kElems);
   ASSERT_EQ(storage.AccessResult().tasks.size(), kElems);
   ASSERT_EQ(storage.AccessResult().roots.size(), kElems);
 
   for (const auto& i : storage.AccessResult().roots) {
-    tm.Delete(i);
+    tm->Delete(i);
   }
-  storage = tm.Show();
+  storage = tm->Show();
 
   ASSERT_EQ(storage.AccessResult().parents.size(), 0);
   ASSERT_EQ(storage.AccessResult().tasks.size(), 0);
@@ -93,20 +91,18 @@ TEST_F(TaskManagerTest, ProperDeletion) {
 
 TEST_F(TaskManagerTest, ProperCompletion) {
   constexpr int kElems = 512;
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
-    tm.Add(task);
+    tm->Add(task);
   }
-  auto storage = tm.Show().AccessResult();
+  auto storage = tm->Show().AccessResult();
 
   for (const auto& i : storage.roots) {
-    tm.Complete(i);
+    tm->Complete(i);
   }
 
-  storage = tm.Show().AccessResult();
+  storage = tm->Show().AccessResult();
   for (const auto& i : storage.roots) {
     ASSERT_EQ(storage.tasks[i].progress(), Task::kCompleted);
   }
@@ -114,33 +110,103 @@ TEST_F(TaskManagerTest, ProperCompletion) {
 
 TEST_F(TaskManagerTest, ProperEdition) {
   constexpr int kElems = 256;
-  TaskManager tm{get_default_task_id_producer()};
-  TaskFactory tf;
   std::vector<Task> vec_tasks;
 
   for (int i = 0; i != kElems; ++i) {
     auto task = tf.GetNextTask();
     auto new_task = tf.GetNextTask();
-    tm.Add(task);
-    auto storage = tm.Show().AccessResult();
+    tm->Add(task);
+    auto storage = tm->Show().AccessResult();
     auto res = std::find_if(storage.tasks.cbegin(), storage.tasks.cend(),
                             [task](const auto& t) { return t.second == task; });
-    tm.Edit(res->first, new_task);
+    tm->Edit(res->first, new_task);
     vec_tasks.push_back(new_task);
   }
 
   for (const auto& i : vec_tasks) {
-    auto storage = tm.Show().AccessResult();
+    auto storage = tm->Show().AccessResult();
     auto iter = std::find_if(storage.tasks.cbegin(), storage.tasks.cend(),
                              [i](const auto& t) { return t.second == i; });
-    tm.Delete(iter->first);
+    tm->Delete(iter->first);
   }
 
-  auto storage = tm.Show().AccessResult();
+  auto storage = tm->Show().AccessResult();
 
   ASSERT_EQ(storage.parents.size(), 0);
   ASSERT_EQ(storage.tasks.size(), 0);
   ASSERT_EQ(storage.roots.size(), 0);
+}
+
+TEST_F(TaskManagerTest, MustAddLabel) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = tm->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
+  auto storage = tm->Show().AccessResult();
+  auto got_task = storage.tasks.at(id);
+  ASSERT_EQ(got_task.labels_size(), 1);
+  EXPECT_EQ(got_task.labels()[0].name(), label.name());
+}
+
+TEST_F(TaskManagerTest, MustDeleteLabel) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = tm->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
+  result = tm->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
+  auto storage = tm->Show().AccessResult();
+  auto got_task = storage.tasks.at(id);
+  ASSERT_EQ(got_task.labels_size(), 0);
+}
+
+TEST_F(TaskManagerTest, AddLabelWithNotPresentIdMustResultInkNotPresentId) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  tm->Delete(id);
+  Label label;
+  label.set_name("label1");
+  auto result = tm->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentId);
+}
+
+TEST_F(TaskManagerTest, AddLabelWithRepeatedLabelMustNotAddItAndReturnkOk) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = tm->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
+  result = tm->AddLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kOk);
+  auto storage = tm->Show().AccessResult();
+  auto got_task = storage.tasks.at(id);
+  ASSERT_EQ(got_task.labels_size(), 1);
+  EXPECT_EQ(got_task.labels()[0].name(), label.name());
+}
+
+TEST_F(TaskManagerTest, DeleteLabelWithNotPresentIdMustResultInkNotPresentId) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  tm->Delete(id);
+  Label label;
+  label.set_name("label1");
+  auto result = tm->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentId);
+}
+
+TEST_F(TaskManagerTest,
+       DeleteLabelWithNotPresentLabelMustResultInkNotPresentLabel) {
+  auto task = tf.GetNextTask();
+  auto id = tm->Add(task).AccessResult();
+  Label label;
+  label.set_name("label1");
+  auto result = tm->DeleteLabel(id, label);
+  ASSERT_EQ(result.GetStatus(), TaskManager::Status::kNotPresentLabel);
 }
 
 // TODO: Add tests for nested things


### PR DESCRIPTION
Created new `.proto` file `Label.proto`.
Task has new repeated field `labels`.
`TaskManager` and `ModelController` now have `AddLabel` and `DeleteLabel` methods.
`AddLabelCommand`/`DeleteLabelCommand` are implemented.
`AddLabelStep`/`DeleteLabelStep` are implemented.
`add_label`(`al`) and `delete_label`(`dl`) are now available as command for input.