### PR TITLE
Add logging using Boost::log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-language-extension-token)
+add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-language-extension-token -fvisibility=hidden)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=nullability")
 
@@ -17,6 +17,9 @@ find_program(PROTOBUF_EXECUTABLE protoc)
 
 find_package(gRPC REQUIRED)
 find_program(GRPC_PROTOBUF_PLUGIN grpc_cpp_plugin)
+
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost COMPONENTS log log_setup REQUIRED)
 
 set(PROTOBUF_DIR ${CMAKE_SOURCE_DIR}/protobuf)
 set(PROTOBUF_CPP_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf)
@@ -64,7 +67,10 @@ file(GLOB_RECURSE TaskManager_SRCS CONFIGURE_DEPENDS
 add_library(TaskManager
   STATIC ${TaskManager_SRCS} ${PROTOBUF_GENERATED_SRCS}
 )
-target_link_libraries(TaskManager PUBLIC protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection)
+target_link_libraries(TaskManager PUBLIC
+    protobuf::libprotobuf
+    gRPC::grpc++ gRPC::grpc++_reflection Boost::log Boost::log_setup)
+target_include_directories(TaskManager PUBLIC ${Boost_INCLUDE_DIRS})
 
 add_executable(main
         src/main.cc)

--- a/src/client.cc
+++ b/src/client.cc
@@ -3,9 +3,17 @@
 #include "interactor/small_steps/default/DefaultSmallStepFactory.h"
 #include "interactor/state_machine/StateMachineController.h"
 #include "interactor/validator/DefaultValidator.h"
+#include "logging/DefaultLogFacility.h"
 
 int main() {
   using namespace task_manager;
+
+  {
+    auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
+    logging::SetUp();
+    logging::CreateFileLog("client", format, logging::severinity::debug);
+  }
+
   auto validator = std::make_shared<DefaultValidator>();
   auto io_facility = std::make_shared<IostreamIoFacility>();
   auto small_step_factory =

--- a/src/interactor/state_machine/commands/AddTaskCommand.cc
+++ b/src/interactor/state_machine/commands/AddTaskCommand.cc
@@ -1,13 +1,28 @@
+#include <boost/log/attributes/named_scope.hpp>
+
 #include "interactor/state_machine/commands/Commands.h"
+#include "logging/DefaultLogFacility.h"
 
 namespace task_manager {
 AddTaskCommand::AddTaskCommand(Task task) : task_(std::move(task)) {}
 
 CommandResult AddTaskCommand::execute(ModelController& model_controller) {
+  BOOST_LOG_NAMED_SCOPE("AddTaskCommand::execute");
+  auto& logger = logging::GetDefaultLogger();
+
+  BOOST_LOG_SEV(logger, logging::severinity::info)
+      << "Adding task: " << task_.DebugString();
+
   CommandResult command_result;
   auto result = model_controller.Add(task_);
   if (result) {
     command_result.task_id = result.AccessResult();
+
+    BOOST_LOG_SEV(logger, logging::severinity::info)
+        << "Ok. New TaskId: " << result.AccessResult().DebugString();
+  } else {
+    BOOST_LOG_SEV(logger, logging::severinity::info)
+        << "Error: " << static_cast<int>(result.GetStatus());
   }
   command_result.status = result.GetStatus();
   return command_result;

--- a/src/interactor/state_machine/commands/GetSpecifiedTasksCommand.cc
+++ b/src/interactor/state_machine/commands/GetSpecifiedTasksCommand.cc
@@ -1,15 +1,30 @@
+#include <boost/log/attributes/named_scope.hpp>
+
 #include "interactor/state_machine/commands/Commands.h"
+#include "logging/DefaultLogFacility.h"
 
 namespace task_manager {
 GetSpecifiedTasksCommand::GetSpecifiedTasksCommand(std::vector<TaskId> task_ids)
     : task_ids_(std::move(task_ids)) {}
 
 CommandResult GetSpecifiedTasksCommand::execute(
-    ModelController &model_controller) {
+    ModelController& model_controller) {
+  BOOST_LOG_NAMED_SCOPE("GetSpecifiedTasksCommand::execute");
+  auto& logger = logging::GetDefaultLogger();
+
+  BOOST_LOG_SEV(logger, logging::severinity::info)
+      << "Querying " << task_ids_.size() << " ids";
+
   CommandResult command_result;
   auto result = model_controller.GetSpecificSolidTasks(std::move(task_ids_));
   if (result) {
     command_result.solid_tasks = result.AccessResult();
+
+    BOOST_LOG_SEV(logger, logging::severinity::info)
+        << "Ok. Got " << result.AccessResult().size() << " tasks";
+  } else {
+    BOOST_LOG_SEV(logger, logging::severinity::info)
+        << "Error: " << static_cast<int>(result.GetStatus());
   }
   command_result.status = result.GetStatus();
   return command_result;

--- a/src/logging/DefaultLogFacility.cc
+++ b/src/logging/DefaultLogFacility.cc
@@ -1,0 +1,51 @@
+#include "logging/DefaultLogFacility.h"
+
+#include <boost/log/attributes.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <fstream>
+
+namespace task_manager {
+namespace logging {
+
+namespace sources = boost::log::sources;
+namespace trivial = boost::log::trivial;
+namespace attributes = boost::log::attributes;
+namespace sinks = boost::log::sinks;
+namespace expressions = boost::log::expressions;
+namespace keywords = boost::log::keywords;
+
+static sources::severity_logger<trivial::severity_level> default_logger;
+
+sources::severity_logger<trivial::severity_level>& GetDefaultLogger() {
+  return default_logger;
+}
+
+void CreateFileLog(logging::trivial::severity_level level,
+                   const std::string& format) {
+  boost::log::add_file_log(
+      keywords::file_name = "sample_%N.log",
+      keywords::rotation_size = 10 * 1024 * 1024, keywords::auto_flush = true,
+      keywords::time_based_rotation =
+          sinks::file::rotation_at_time_point(0, 0, 0),
+      keywords::filter = logging::trivial::severity >= level,
+      keywords::format = format);
+}
+
+void SetUp() {
+  boost::log::add_common_attributes();
+
+  auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
+
+  CreateFileLog(logging::trivial::trace, format);
+
+  boost::log::add_console_log(
+      std::clog, boost::log::keywords::format = format,
+      keywords::filter = logging::trivial::severity >= logging::trivial::info);
+
+  GetDefaultLogger().add_attribute("Scope", attributes::named_scope());
+}
+}  // namespace logging
+}  // namespace task_manager

--- a/src/logging/DefaultLogFacility.cc
+++ b/src/logging/DefaultLogFacility.cc
@@ -23,10 +23,11 @@ sources::severity_logger<trivial::severity_level>& GetDefaultLogger() {
   return default_logger;
 }
 
-void CreateFileLog(logging::trivial::severity_level level,
-                   const std::string& format) {
+void CreateFileLog(const std::string& filename, const std::string& format,
+                   severinity level) {
+  auto rotated_filename = filename + "_%N.log";
   boost::log::add_file_log(
-      keywords::file_name = "sample_%N.log",
+      keywords::file_name = rotated_filename.c_str(),
       keywords::rotation_size = 10 * 1024 * 1024, keywords::auto_flush = true,
       keywords::time_based_rotation =
           sinks::file::rotation_at_time_point(0, 0, 0),
@@ -34,17 +35,14 @@ void CreateFileLog(logging::trivial::severity_level level,
       keywords::format = format);
 }
 
-void SetUp() {
-  boost::log::add_common_attributes();
-
-  auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
-
-  CreateFileLog(logging::trivial::trace, format);
-
+void CreateConsoleLog(const std::string& format, severinity level) {
   boost::log::add_console_log(
       std::clog, boost::log::keywords::format = format,
-      keywords::filter = logging::trivial::severity >= logging::trivial::info);
+      keywords::filter = logging::trivial::severity >= level);
+}
 
+void SetUp() {
+  boost::log::add_common_attributes();
   GetDefaultLogger().add_attribute("Scope", attributes::named_scope());
 }
 }  // namespace logging

--- a/src/logging/DefaultLogFacility.h
+++ b/src/logging/DefaultLogFacility.h
@@ -12,6 +12,11 @@ boost::log::sources::severity_logger<boost::log::trivial::severity_level>&
 GetDefaultLogger();
 
 void SetUp();
+
+void CreateConsoleLog(const std::string& format, severinity level);
+
+void CreateFileLog(const std::string& filename, const std::string& format,
+                   severinity level);
 }  // namespace logging
 }  // namespace task_manager
 

--- a/src/logging/DefaultLogFacility.h
+++ b/src/logging/DefaultLogFacility.h
@@ -1,0 +1,18 @@
+#ifndef TASKMANAGER_SRC_LOGGING_DEFAULTLOGFACILITY_H_
+#define TASKMANAGER_SRC_LOGGING_DEFAULTLOGFACILITY_H_
+
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/trivial.hpp>
+
+namespace task_manager {
+namespace logging {
+using severinity = boost::log::trivial::severity_level;
+
+boost::log::sources::severity_logger<boost::log::trivial::severity_level>&
+GetDefaultLogger();
+
+void SetUp();
+}  // namespace logging
+}  // namespace task_manager
+
+#endif  // TASKMANAGER_SRC_LOGGING_DEFAULTLOGFACILITY_H_

--- a/src/model/DefaultModelController.cc
+++ b/src/model/DefaultModelController.cc
@@ -1,5 +1,10 @@
 #include "DefaultModelController.h"
 
+#include <google/protobuf/util/time_util.h>
+
+#include <boost/log/attributes/named_scope.hpp>
+
+#include "logging/DefaultLogFacility.h"
 #include "model/task_manager/TaskManager.h"
 #include "persistence/Persistence.h"
 #include "utils/TaskIdUtils.h"
@@ -27,10 +32,27 @@ DefaultModelController::DefaultModelController(
       persistence_(std::move(persistence)) {}
 
 OperationResult<MCStatus, TaskId> DefaultModelController::Add(Task task) {
+  BOOST_LOG_NAMED_SCOPE("DefaultModelController::Add(Task task)");
+  auto& logger = logging::GetDefaultLogger();
+
+  auto to_log = task;
   auto result = task_manager_->Add(std::move(task));
   if (result) {
+    BOOST_LOG_SEV(logger, logging::severinity::info)
+        << "Added task: "
+        << "TITLE:'" << to_log.title() << "' DUEDATE:" << to_log.due_date()
+        << " PRIORITY:" << Task_Priority_Name(to_log.priority())
+        << " PROGRESS:" << Task_Progress_Name(to_log.progress())
+        << " with id:" << result.AccessResult().id();
     return OperationResult<Status, TaskId>::Ok(result.AccessResult());
   }
+
+  BOOST_LOG_SEV(logger, logging::severinity::info)
+      << "Failed to add task: "
+      << "TITLE:'" << to_log.title() << "' DUEDATE:" << to_log.due_date()
+      << " PRIORITY:" << Task_Priority_Name(to_log.priority())
+      << " PROGRESS:" << Task_Progress_Name(to_log.progress());
+
   return OperationResult<Status, TaskId>::Error(
       TMStatusToMCStatus(result.GetStatus()));
 }

--- a/src/model/DefaultModelController.cc
+++ b/src/model/DefaultModelController.cc
@@ -147,9 +147,29 @@ DefaultModelController::GetAllSolidTasks() {
 
 OperationResult<MCStatus, SolidTasks>
 DefaultModelController::GetSpecificSolidTasks(std::vector<TaskId> ids) {
+  BOOST_LOG_NAMED_SCOPE("DefaultModelController::GetSpecificSolidTasks");
+
+  auto& logger = logging::GetDefaultLogger();
+
+  {
+    boost::log::record rec = logger.open_record(boost::log::keywords::severity =
+                                                    logging::severinity::info);
+    if (rec) {
+      boost::log::record_ostream strm(rec);
+      strm << "getting tasks with ids: ";
+      for (const auto& i : ids) {
+        strm << i.id() << " ";
+      }
+      strm.flush();
+      logger.push_record(std::move(rec));
+    }
+  }
+
   auto storage = task_manager_->Show().AccessResult();
   for (const auto& i : ids) {
     if (storage.tasks.find(i) == storage.tasks.end()) {
+      BOOST_LOG_SEV(logger, logging::severinity::info)
+          << "id " << i.id() << " was not found";
       return OperationResult<Status, SolidTasks>::Error(Status::kNotPresentId);
     }
   }

--- a/src/server.cc
+++ b/src/server.cc
@@ -11,7 +11,12 @@
 
 int main() {
   using namespace task_manager;
-  logging::SetUp();
+
+  {
+    auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
+    logging::SetUp();
+    logging::CreateFileLog("server", format, logging::severinity::debug);
+  }
 
   auto& logger = logging::GetDefaultLogger();
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -36,16 +36,10 @@ int main() {
   DefaultTaskService service(std::move(model_controller));
 
   grpc::ServerBuilder builder;
-  // Listen on the given address without any authentication mechanism.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  // Register "service" as the instance through which we'll communicate with
-  // clients. In this case it corresponds to an *synchronous* service.
   builder.RegisterService(&service);
-  // Finally assemble the server.
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
 
-  // Wait for the server to shutdown. Note that some other thread must be
-  // responsible for shutting down the server for this call to ever return.
   server->Wait();
   BOOST_LOG_SEV(logger, logging::severinity::info) << "Server shutdown";
 

--- a/src/service/DefaultTaskService.cc
+++ b/src/service/DefaultTaskService.cc
@@ -33,10 +33,7 @@ grpc::Status DefaultTaskService::AddTask(
   auto &logger = logging::GetDefaultLogger();
 
   BOOST_LOG_SEV(logger, logging::severinity::debug)
-      << "request: "
-      << "TITLE:'" << request->title() << "' DUEDATE:" << request->due_date()
-      << " PRIORITY:" << Task_Priority_Name(request->priority())
-      << " PROGRESS:" << Task_Progress_Name(request->progress());
+      << "request: " << request->DebugString();
 
   auto result = model_controller_->Add(*request);
   if (result) {
@@ -45,16 +42,8 @@ grpc::Status DefaultTaskService::AddTask(
   response->set_status(
       ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
 
-  if (response->has_task_id()) {
-    BOOST_LOG_SEV(logger, logging::severinity::debug)
-        << "response: "
-        << "STATUS:" << TaskServiceStatus_Name(response->status())
-        << " TASKID:" << response->task_id().id();
-  } else {
-    BOOST_LOG_SEV(logger, logging::severinity::debug)
-        << "response: "
-        << "STATUS:" << TaskServiceStatus_Name(response->status());
-  }
+  BOOST_LOG_SEV(logger, logging::severinity::debug) << response->DebugString();
+
   return grpc::Status::OK;
 }
 
@@ -115,21 +104,10 @@ grpc::Status DefaultTaskService::GetSpecifiedSolidTasks(
     ::grpc::ServerContext *, const TaskIdsRequest *request,
     ::task_manager::SolidTasksResponse *response) {
   BOOST_LOG_NAMED_SCOPE("DefaultTaskService::GetSpecifiedSolidTasks");
-
   auto &logger = logging::GetDefaultLogger();
-  {
-    boost::log::record rec = logger.open_record(boost::log::keywords::severity =
-                                                    logging::severinity::debug);
-    if (rec) {
-      boost::log::record_ostream strm(rec);
-      strm << "request: ";
-      for (const auto &i : request->task_ids()) {
-        strm << i.id() << " ";
-      }
-      strm.flush();
-      logger.push_record(std::move(rec));
-    }
-  }
+
+  BOOST_LOG_SEV(logger, logging::severinity::debug)
+      << "request: " << request->DebugString();
 
   std::vector<TaskId> ids;
   std::copy(request->task_ids().cbegin(), request->task_ids().cend(),

--- a/src/service/DefaultTaskService.cc
+++ b/src/service/DefaultTaskService.cc
@@ -97,17 +97,17 @@ grpc::Status DefaultTaskService::Delete(::grpc::ServerContext *,
     return grpc::Status::OK;
 }
 
-grpc::Status DefaultTaskService::GetAllSolidTasks(::grpc::ServerContext *,
-                                                  const ::google::protobuf::Empty *,
-                                                  ::task_manager::SolidTasksResponse *response) {
-    auto result = model_controller_->GetAllSolidTasks();
-    if (result) {
-        for (const auto &i: result.AccessResult()) {
-            response->add_solid_tasks()->CopyFrom(i);
-        }
+grpc::Status DefaultTaskService::GetAllSolidTasks(
+    ::grpc::ServerContext *, const ::google::protobuf::Empty *,
+    ::task_manager::SolidTasksResponse *response) {
+  auto result = model_controller_->GetAllSolidTasks();
+  if (result) {
+    for (const auto &i : result.AccessResult()) {
+      response->add_solid_tasks()->CopyFrom(i);
     }
+  }
     response->set_status(
-        ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
+    ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
     return grpc::Status::OK;
 }
 
@@ -135,8 +135,7 @@ grpc::Status DefaultTaskService::GetSpecifiedSolidTasks(
   std::copy(request->task_ids().cbegin(), request->task_ids().cend(),
             std::back_inserter(ids));
   auto result = model_controller_->GetSpecificSolidTasks(std::move(ids));
-  if (result)
-  {
+  if (result) {
     for (const auto &i : result.AccessResult()) {
       response->add_solid_tasks()->CopyFrom(i);
     }

--- a/src/service/DefaultTaskService.cc
+++ b/src/service/DefaultTaskService.cc
@@ -14,11 +14,11 @@ namespace task_manager {
 TaskServiceStatus ConvertModelControllerStatusToTaskServiceStatus(
     ModelController::Status status) {
     switch (status) {
-        case ModelController::Status::kNotPresentId:return TaskServiceStatus::kNotPresentId;
-        case ModelController::Status::kOk:return TaskServiceStatus::kOk;
-        case ModelController::Status::kLoadFailure:return TaskServiceStatus::kLoadFailure;
-        case ModelController::Status::kSaveFailure:return TaskServiceStatus::kSaveFailure;
-        case ModelController::Status::kNotPresentLabel:return TaskServiceStatus::kNotPresentLabel;
+        case ModelController::Status::kNotPresentId: { return TaskServiceStatus::kNotPresentId; }
+        case ModelController::Status::kOk: { return TaskServiceStatus::kOk; }
+        case ModelController::Status::kLoadFailure: { return TaskServiceStatus::kLoadFailure; }
+        case ModelController::Status::kSaveFailure: { return TaskServiceStatus::kSaveFailure; }
+        case ModelController::Status::kNotPresentLabel: { return TaskServiceStatus::kNotPresentLabel; }
     }
 }
 
@@ -26,25 +26,25 @@ DefaultTaskService::DefaultTaskService(
     std::unique_ptr<ModelController> model_controller)
     : model_controller_(std::move(model_controller)) {}
 
-grpc::Status DefaultTaskService::AddTask(
-    ::grpc::ServerContext *, const ::task_manager::Task *request,
-    ::task_manager::TaskIdResponse *response) {
-  BOOST_LOG_NAMED_SCOPE("DefaultTaskService::AddTask");
-  auto &logger = logging::GetDefaultLogger();
+grpc::Status DefaultTaskService::AddTask(::grpc::ServerContext *,
+                                         const ::task_manager::Task *request,
+                                         ::task_manager::TaskIdResponse *response) {
+    BOOST_LOG_NAMED_SCOPE("DefaultTaskService::AddTask");
+    auto &logger = logging::GetDefaultLogger();
 
-  BOOST_LOG_SEV(logger, logging::severinity::debug)
-      << "request: " << request->DebugString();
+    BOOST_LOG_SEV(logger, logging::severinity::debug)
+        << "request: " << request->DebugString();
 
-  auto result = model_controller_->Add(*request);
-  if (result) {
-    response->set_allocated_task_id(new TaskId(result.AccessResult()));
-  }
-  response->set_status(
-      ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
+    auto result = model_controller_->Add(*request);
+    if (result) {
+        response->set_allocated_task_id(new TaskId(result.AccessResult()));
+    }
+    response->set_status(
+        ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
 
-  BOOST_LOG_SEV(logger, logging::severinity::debug) << response->DebugString();
+    BOOST_LOG_SEV(logger, logging::severinity::debug) << response->DebugString();
 
-  return grpc::Status::OK;
+    return grpc::Status::OK;
 }
 
 grpc::Status DefaultTaskService::AddSubtask(::grpc::ServerContext *,
@@ -86,44 +86,44 @@ grpc::Status DefaultTaskService::Delete(::grpc::ServerContext *,
     return grpc::Status::OK;
 }
 
-grpc::Status DefaultTaskService::GetAllSolidTasks(
-    ::grpc::ServerContext *, const ::google::protobuf::Empty *,
-    ::task_manager::SolidTasksResponse *response) {
-  auto result = model_controller_->GetAllSolidTasks();
-  if (result) {
-    for (const auto &i : result.AccessResult()) {
-      response->add_solid_tasks()->CopyFrom(i);
+grpc::Status DefaultTaskService::GetAllSolidTasks(::grpc::ServerContext *,
+                                                  const ::google::protobuf::Empty *,
+                                                  ::task_manager::SolidTasksResponse *response) {
+    auto result = model_controller_->GetAllSolidTasks();
+    if (result) {
+        for (const auto &i: result.AccessResult()) {
+            response->add_solid_tasks()->CopyFrom(i);
+        }
     }
-  }
     response->set_status(
-    ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
+        ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
     return grpc::Status::OK;
 }
 
-grpc::Status DefaultTaskService::GetSpecifiedSolidTasks(
-    ::grpc::ServerContext *, const TaskIdsRequest *request,
-    ::task_manager::SolidTasksResponse *response) {
-  BOOST_LOG_NAMED_SCOPE("DefaultTaskService::GetSpecifiedSolidTasks");
-  auto &logger = logging::GetDefaultLogger();
+grpc::Status DefaultTaskService::GetSpecifiedSolidTasks(::grpc::ServerContext *,
+                                                        const TaskIdsRequest *request,
+                                                        ::task_manager::SolidTasksResponse *response) {
+    BOOST_LOG_NAMED_SCOPE("DefaultTaskService::GetSpecifiedSolidTasks");
+    auto &logger = logging::GetDefaultLogger();
 
-  BOOST_LOG_SEV(logger, logging::severinity::debug)
-      << "request: " << request->DebugString();
+    BOOST_LOG_SEV(logger, logging::severinity::debug)
+        << "request: " << request->DebugString();
 
-  std::vector<TaskId> ids;
-  std::copy(request->task_ids().cbegin(), request->task_ids().cend(),
-            std::back_inserter(ids));
-  auto result = model_controller_->GetSpecificSolidTasks(std::move(ids));
-  if (result) {
-    for (const auto &i : result.AccessResult()) {
-      response->add_solid_tasks()->CopyFrom(i);
+    std::vector<TaskId> ids;
+    std::copy(request->task_ids().cbegin(), request->task_ids().cend(),
+              std::back_inserter(ids));
+    auto result = model_controller_->GetSpecificSolidTasks(std::move(ids));
+    if (result) {
+        for (const auto &i: result.AccessResult()) {
+            response->add_solid_tasks()->CopyFrom(i);
+        }
     }
-  }
-  response->set_status(
-      ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
+    response->set_status(
+        ConvertModelControllerStatusToTaskServiceStatus(result.GetStatus()));
 
-  BOOST_LOG_SEV(logger, logging::severinity::debug)
-      << "response: " << TaskServiceStatus_Name(response->status());
-  return grpc::Status::OK;
+    BOOST_LOG_SEV(logger, logging::severinity::debug)
+        << "response: " << TaskServiceStatus_Name(response->status());
+    return grpc::Status::OK;
 }
 
 grpc::Status DefaultTaskService::Load(::grpc::ServerContext *,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 Find_Package(GTest REQUIRED)
 
 set(TASK_MANAGER_LINK_GTEST
-  GTest::gtest GTest::gtest_main GTest::gmock)
+  GTest::gtest GTest::gmock)
 
 file(GLOB_RECURSE Tests_SRCS CONFIGURE_DEPENDS
     "*.h"
@@ -19,5 +19,7 @@ target_link_libraries(
   ${TASK_MANAGER_LINK_GTEST}
   TaskManager
 )
+
+add_executable(test_main main.cc ModelTest)
 
 gtest_discover_tests(ModelTest)

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <boost/log/core.hpp>
+
+int main(int argc, char** argv) {
+  boost::log::core::get()->set_logging_enabled(false);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Added file where all logging setup is located: `DefaultLogFacitity`.
- Added logging on `server`/`client` startup.
- Added `DEBUG` logging in `DefaultTaskService::AddTask` and `DefaultTaskService::GetSpecifiedSolidTasks`.
- Added `INFO` logging in `DefaultModelController::GetSpecificSolidTasks` and `DefaultModelController::Add`.
- Added `INFO` logging in `AddTaskCommand` and `GetSpecifiedTasksCommand`.
- Logging is disabled in tests.