### PR TITLE
Add program options using Boost::program_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(gRPC REQUIRED)
 find_program(GRPC_PROTOBUF_PLUGIN grpc_cpp_plugin)
 
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost COMPONENTS log log_setup REQUIRED)
+find_package(Boost COMPONENTS log log_setup program_options REQUIRED)
 
 set(PROTOBUF_DIR ${CMAKE_SOURCE_DIR}/protobuf)
 set(PROTOBUF_CPP_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf)
@@ -69,7 +69,7 @@ add_library(TaskManager
 )
 target_link_libraries(TaskManager PUBLIC
     protobuf::libprotobuf
-    gRPC::grpc++ gRPC::grpc++_reflection Boost::log Boost::log_setup)
+    gRPC::grpc++ gRPC::grpc++_reflection Boost::log Boost::log_setup Boost::program_options)
 target_include_directories(TaskManager PUBLIC ${Boost_INCLUDE_DIRS})
 
 add_executable(main

--- a/src/client.cc
+++ b/src/client.cc
@@ -1,3 +1,5 @@
+#include <boost/program_options.hpp>
+
 #include "client/TaskServiceModelController.h"
 #include "interactor/io_facility/iostream/IostreamIoFacility.h"
 #include "interactor/small_steps/default/DefaultSmallStepFactory.h"
@@ -5,14 +7,49 @@
 #include "interactor/validator/DefaultValidator.h"
 #include "logging/DefaultLogFacility.h"
 
-int main() {
+int main(int argc, char** argv) {
   using namespace task_manager;
+  namespace po = boost::program_options;
 
-  {
-    auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
-    logging::SetUp();
-    logging::CreateFileLog("client", format, logging::severinity::debug);
+  std::string log_level_str;
+  std::string host;
+  std::string port;
+  po::options_description desc("Allowed options");
+  desc.add_options()(
+      "level,l", po::value<std::string>(&log_level_str)->default_value("info"),
+      "Level of logging")(
+      "host,h", po::value<std::string>(&host)->default_value("127.0.0.1"),
+      "Host to connect to")(
+      "port,p", po::value<std::string>(&port)->default_value("50051"),
+      "Port to connect to");
+
+  po::variables_map opts;
+  po::store(po::parse_command_line(argc, argv, desc), opts);
+  po::notify(opts);
+
+  auto log_level = logging::ConvertStringToLogLevel(log_level_str);
+
+  if (log_level) {
+    {
+      auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
+      logging::SetUp();
+      logging::CreateFileLog("client", format, *log_level);
+    }
+  } else {
+    std::cerr << "Invalid level option.\n"
+                 "  Allowed options: \n"
+                 "   - 'trace'\n"
+                 "   - 'debug'\n"
+                 "   - 'info'\n"
+                 "   - 'warning'\n"
+                 "   - 'error'\n"
+                 "   - 'fatal'\n";
+    return 1;
   }
+
+  auto& logger = logging::GetDefaultLogger();
+  BOOST_LOG_SEV(logger, logging::severinity::info)
+      << "Connecting to " << host << ":" << port;
 
   auto validator = std::make_shared<DefaultValidator>();
   auto io_facility = std::make_shared<IostreamIoFacility>();
@@ -22,9 +59,9 @@ int main() {
   auto state_machine = std::make_unique<StateMachine>(validator, io_facility,
                                                       small_step_factory);
 
-  std::string server_addr{"127.0.0.1:50051"};
+  std::string server_address = host + ":" + port;
   auto stub = std::make_unique<TaskService::Stub>(
-      grpc::CreateChannel(server_addr, grpc::InsecureChannelCredentials()));
+      grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials()));
   auto task_service_model_controller =
       std::make_shared<TaskServiceModelController>(std::move(stub));
   StateMachineController ctrl{task_service_model_controller,

--- a/src/logging/DefaultLogFacility.cc
+++ b/src/logging/DefaultLogFacility.cc
@@ -45,5 +45,14 @@ void SetUp() {
   boost::log::add_common_attributes();
   GetDefaultLogger().add_attribute("Scope", attributes::named_scope());
 }
+
+std::optional<severinity> ConvertStringToLogLevel(const std::string& str) {
+  severinity sev;
+  auto result = boost::log::trivial::from_string(str.c_str(), str.size(), sev);
+  if (result) {
+    return sev;
+  }
+  return {};
+}
 }  // namespace logging
 }  // namespace task_manager

--- a/src/logging/DefaultLogFacility.h
+++ b/src/logging/DefaultLogFacility.h
@@ -17,6 +17,8 @@ void CreateConsoleLog(const std::string& format, severinity level);
 
 void CreateFileLog(const std::string& filename, const std::string& format,
                    severinity level);
+
+std::optional<severinity> ConvertStringToLogLevel(const std::string& str);
 }  // namespace logging
 }  // namespace task_manager
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -2,6 +2,7 @@
 #include <grpcpp/health_check_service_interface.h>
 
 #include <boost/log/trivial.hpp>
+#include <boost/program_options.hpp>
 
 #include "logging/DefaultLogFacility.h"
 #include "model/DefaultModelController.h"
@@ -9,12 +10,38 @@
 #include "persistence/FilePersistence.h"
 #include "service/DefaultTaskService.h"
 
-int main() {
+int main(int argc, char** argv) {
   using namespace task_manager;
-  {
-    auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
-    logging::SetUp();
-    logging::CreateFileLog("server", format, logging::severinity::debug);
+  namespace po = boost::program_options;
+
+  std::string log_level_str;
+  po::options_description desc("Allowed options");
+  desc.add_options()(
+      "level,l", po::value<std::string>(&log_level_str)->default_value("info"),
+      "Level of logging");
+
+  po::variables_map opts;
+  po::store(po::parse_command_line(argc, argv, desc), opts);
+  po::notify(opts);
+
+  auto log_level = logging::ConvertStringToLogLevel(log_level_str);
+
+  if (log_level) {
+    {
+      auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
+      logging::SetUp();
+      logging::CreateFileLog("server", format, *log_level);
+    }
+  } else {
+    std::cerr << "Invalid level option.\n"
+                 "  Allowed options: \n"
+                 "   - 'trace'\n"
+                 "   - 'debug'\n"
+                 "   - 'info'\n"
+                 "   - 'warning'\n"
+                 "   - 'error'\n"
+                 "   - 'fatal'\n";
+    return 1;
   }
 
   auto& logger = logging::GetDefaultLogger();

--- a/src/server.cc
+++ b/src/server.cc
@@ -11,7 +11,6 @@
 
 int main() {
   using namespace task_manager;
-
   {
     auto format = "[%TimeStamp%][%Severity%](%Scope%): %Message%";
     logging::SetUp();

--- a/src/service/DefaultTaskService.cc
+++ b/src/service/DefaultTaskService.cc
@@ -4,6 +4,7 @@
 
 #include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/core.hpp>
+#include <boost/log/trivial.hpp>
 
 #include "logging/DefaultLogFacility.h"
 #include "model/ModelController.h"

--- a/src/service/DefaultTaskService.cc
+++ b/src/service/DefaultTaskService.cc
@@ -4,7 +4,6 @@
 
 #include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/core.hpp>
-#include <boost/log/trivial.hpp>
 
 #include "logging/DefaultLogFacility.h"
 #include "model/ModelController.h"


### PR DESCRIPTION
- `server` now can accept several cli arguments:
  - `host`/`h`. Host to connect to. 
  - `port`/`p`. Port to connect to.
  - `level`/`l`. Level of logging
- `client` now can accept `level`/`l` of logging.